### PR TITLE
fix: avoid sync path fix at startup

### DIFF
--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -74,9 +74,14 @@ const handle = createLoggedHandler(logger);
 
 let proxyWorker: Worker | null = null;
 
-// Needed, otherwise electron in MacOS/Linux will not be able
-// to find node/pnpm.
-fixPath();
+// Lazily fix the PATH so we don't slow down startup on Linux.
+let pathFixed = false;
+function ensurePath() {
+  if (!pathFixed) {
+    fixPath();
+    pathFixed = true;
+  }
+}
 
 async function executeApp({
   appPath,
@@ -107,6 +112,7 @@ async function executeAppLocalNode({
   event: Electron.IpcMainInvokeEvent;
   isNeon: boolean;
 }): Promise<void> {
+  ensurePath();
   const spawnedProcess = spawn(
     "(pnpm install && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)",
     [],


### PR DESCRIPTION
## Summary
- avoid synchronous fixPath call during startup and fix PATH lazily when running apps

## Testing
- `npm run presubmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898fe4ee1f0832991a0fa9a2d9f97fe