### PR TITLE
Use imported directory as project path

### DIFF
--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
 
 export function getDyadAppPath(appPath: string): string {
+  // If the path is already absolute, use it directly.
+  if (path.isAbsolute(appPath)) {
+    return appPath;
+  }
+
   if (IS_TEST_BUILD) {
     const electron = getElectron();
     return path.join(electron!.app.getPath("userData"), "dyad-apps", appPath);


### PR DESCRIPTION
## Summary
- Allow absolute app paths to bypass the dyad-apps directory
- Import apps directly from selected directories without copying
- Validate unique app names and paths during import

## Testing
- `npm test`
- `npm run lint`
- `npm run prettier:check`


------
https://chatgpt.com/codex/tasks/task_e_68990d3392c4832997c523023979275a