### PR TITLE
feat: allow custom app storage

### DIFF
--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -990,6 +990,10 @@ export class IpcClient {
     return this.ipcRenderer.invoke("select-app-folder");
   }
 
+  public async selectStorageFolder(): Promise<{ path: string | null }> {
+    return this.ipcRenderer.invoke("select-storage-folder");
+  }
+
   public async checkAiRules(params: {
     path: string;
   }): Promise<{ exists: boolean }> {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -229,6 +229,11 @@ export interface ApproveProposalResult {
 export interface ImportAppParams {
   path: string;
   appName: string;
+  /**
+   * Optional destination path for the imported app. If omitted, the app's
+   * current path will be used directly without copying.
+   */
+  storagePath?: string;
   installCommand?: string;
   startCommand?: string;
 }

--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -3,6 +3,16 @@ import os from "node:os";
 import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
 
 export function getDyadAppPath(appPath: string): string {
+  if (appPath === "$APP_BASE_PATH") {
+    return "$APP_BASE_PATH";
+  }
+
+  // If an absolute path is provided, use it directly. This allows Dyad to work
+  // with apps that live outside of the default "dyad-apps" directory.
+  if (path.isAbsolute(appPath)) {
+    return appPath;
+  }
+
   if (IS_TEST_BUILD) {
     const electron = getElectron();
     return path.join(electron!.app.getPath("userData"), "dyad-apps", appPath);


### PR DESCRIPTION
## Summary
- allow user to choose storage location when importing apps
- handle absolute app paths and remove dyad-apps duplication
- add E2E test for custom import location
- default import path to the source project folder

## Testing
- `npm test`
- `npx playwright test e2e-tests/import.spec.ts` *(fails: ENOENT: no such file or directory, scandir '/workspace/dyad/out')*

------
https://chatgpt.com/codex/tasks/task_e_68a43938a2f88329b5aba06c4e514492